### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,10 +1,10 @@
 ##
 ## Syntax Highlighting for Arduino IDE
 ##
-PushButton       KEYWORD1
-getEvent         KEYWORD2
-update           KEYWORD2
-print            KEYWORD2
-EV_NONE          LITERAL1
-EV_PRESSED       LITERAL1
-EV_LONG_PRESSED  LITERAL1
+PushButton	KEYWORD1
+getEvent	KEYWORD2
+update	KEYWORD2
+print	KEYWORD2
+EV_NONE	LITERAL1
+EV_PRESSED	LITERAL1
+EV_LONG_PRESSED	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords